### PR TITLE
feat: display name and title underneath the profile pic

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -76,8 +76,8 @@
         }
         .user__link {
             line-height: 0;
-            margin-top: auto;
             width: 100%;
+            margin-bottom: 0.5rem;
         }
         .user__image {
             width: 192px;
@@ -128,15 +128,19 @@
         <div id="users" class="users">
         {{range .Members}}
             <div class="user card block">
-                <div class="name">{{if .Profile.RealName}}{{.Profile.RealName}}{{else}}{{.Name}}{{end}}
-                <a href="slack://user?team={{.TeamId}}&id={{.Id}}">
-                    <img src="https://a.slack-edge.com/436da/marketing/img/meta/favicon-32.png" title="Contact {{.Profile.FirstName}} on Slack" width="16" height="16"/>
-                </a>
-                </div>
-                <div class="title">{{.Profile.Title}}</div>
                 <a class="user__link" href="slack://user?team={{.TeamId}}&id={{.Id}}">
                     <img class="user__image" src="{{.Profile.Image}}" title="Contact {{.Profile.FirstName}} on Slack"/>
                 </a>
+                <div class="user__info">
+                    <div class="name">{{if .Profile.RealName}}{{.Profile.RealName}}{{else}}{{.Name}}{{end}}
+                    <a href="slack://user?team={{.TeamId}}&id={{.Id}}">
+                        <img src="https://a.slack-edge.com/436da/marketing/img/meta/favicon-32.png" title="Contact {{.Profile.FirstName}} on Slack" width="16" height="16"/>
+                    </a>
+                    </div>
+                    {{if .Profile.Title}}
+                        <div class="title">{{.Profile.Title}}</div>
+                    {{end}}
+                </div>
             </div>
         {{end}}
         </div>


### PR DESCRIPTION
Moved text to be displayed below the profile picture

![image](https://user-images.githubusercontent.com/306516/79439186-cc8fec80-7fd4-11ea-9f55-5d43331fc65f.png)

https://tink.slack.com/archives/C6R892DN2/p1587017052101000