### PR TITLE
feat(facelist): Allow .com tink address

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Configuration
 
 facelist is configured by a config file e.g facelist.yaml:
 
-    * emailFilter - Only users with a email ending with this string will be showed
+    * emailFilters - Only users with a email ending with one of these strings will be showed
     * slackTeam - The name of your slack team
     * slackAPIToken - Access token to the Slack api
 

--- a/facelist.yaml
+++ b/facelist.yaml
@@ -1,3 +1,5 @@
-emailFilter: "@tink.se"
+emailFilters:
+  - "@tink.se"
+  - "@tink.com"
 slackTeam: tink
 slackAPIToken: <SECRET_API_TOKEN_GOES_HERE>


### PR DESCRIPTION
### Why
More and more new colleagues are defaulting to @tink.com as their email. 
### What
This change filters for both @tink.se and @tink.com.